### PR TITLE
call time options for tags and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ npm install html-text-to-react
 ```
 
 ## Usage
+```
+import React from 'react';
+import { createElementsFromText } from 'html-text-to-react';
+
+createElementFromText(text, [options]);
+```
+
 
 `createElementsFromText` returns an array of JSX.Element
 ```javascript
@@ -20,8 +27,21 @@ const textWithMarkup = '<strong>Security Report</strong> has been created. Click
 const SecurityReportText = () => (
   <div>{ createElementsFromText(textWithMarkup) }</div>
 );
+
+const textWithMarkup = '<img src="http://example.com/image.png"> Image Label.';
+const SecurityReportImage = () => (
+  <div>{ createElementsFromText(textWithImgMarkup, {tags: ['img'], attributes: ['src']}) }
+)
 ```
+
 
 ## Whitelist
 
-The standard configuration is restrictive on purpose.  If you need to adjust this, fork and update the whitelist fields.
+The default options are 
+```
+{
+  whitelistedHtmlTags: ['a', 'strong'],
+  whitelistedHtmlAttributes: ['id', 'className', 'href', 'data-test', 'rel', 'target'],
+  whiteSpace: 'pre-wrap',
+}
+```

--- a/src/HtmlTextToReact.tsx
+++ b/src/HtmlTextToReact.tsx
@@ -1,36 +1,45 @@
 import * as React from 'react';
 
-// Whitelisting guidelines provided by: https://html5sec.org/
-
-/* Tags that should never be whitelisted without good reason:
- * audio, video, script, applet, body, embed, frame, frameset, html, iframe, style, layer,
- * link, ilayer, meta, object, form, input, source, math, picture, details, comment, base
-*/
-const WHITELISTED_HTML_TAGS = ['a', 'strong'];
-
-/* Attributes that should never be whitelisted without good reason:
- * src, lowsrc, style, on*, form, poster, formaction, dirname, rel, srcdoc, srcset, background
-*/
-const WHITELISTED_HTML_ATTRIBUTES = ['id', 'className', 'href', 'data-test', 'rel', 'target'];
+type WHITELISTED_HTML_TAGS = keyof HTMLElementTagNameMap;
+type WHITELISTED_HTML_ATTRIBUTES = keyof React.AllHTMLAttributes < any > | string;
 
 // Node object isn't available when testing, so hardcode Node.ELEMENT_NODE as 1
 const ELEMENT_NODE_TYPE = 1;
 
 interface OPTIONS {
-  whiteSpace?: 'normal' | 'nowrap' | 'pre' | 'pre-wrap' | 'pre-line' | 'inherit' | 'initial' | 'unset';
+  whitelistedHtmlTags?: WHITELISTED_HTML_TAGS[];
+  whitelistedHtmlAttributes? : WHITELISTED_HTML_ATTRIBUTES[],
+  whiteSpace? : 'normal' | 'nowrap' | 'pre' | 'pre-wrap' | 'pre-line' | 'inherit' | 'initial' | 'unset';
 }
 
+/*
+ * Whitelisting guidelines provided by: https://html5sec.org/
+ *
+ * Attributes that should never be whitelisted without good reason:
+ * src, lowsrc, style, on*, form, poster, formaction, dirname, rel, srcdoc, srcset, background
+ * 
+ * Tags that should never be whitelisted without good reason:
+ * audio, video, script, applet, body, embed, frame, frameset, html, iframe, style, layer,
+ * link, ilayer, meta, object, form, input, source, math, picture, details, comment, base
+*/
 const DEFAULT_OPTIONS: OPTIONS = {
+  whitelistedHtmlTags: ['a', 'strong'],
+  whitelistedHtmlAttributes: ['id', 'className', 'href', 'data-test', 'rel', 'target'],
   whiteSpace: 'pre-wrap',
 }
-
+ 
 /**
  * Returns array of React Elements to avoid blindly evaluating HTML string.
  * Does not support nested tags.
  * @param {string} text
  * * Sample text: I am <strong>an important message</strong> that links to <a href="google.com">Google</a>
  */
-export function createElementsFromText(text: string, options: OPTIONS = DEFAULT_OPTIONS): Array<JSX.Element> {
+export function createElementsFromText(text: string, options?: OPTIONS): Array<JSX.Element> {
+  this.options = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  }
+
   const wrappedText = `<root>${text}</root>`;
 
   /* To parse the string as HTML, we're using DOMParser to create an XML object model
@@ -44,7 +53,7 @@ export function createElementsFromText(text: string, options: OPTIONS = DEFAULT_
     const newAttributes = { key: index, style: {} };
 
     // If a node isn't a valid HTML Element and it isn't in the whitelist, return a span instead
-    const tagName = (nodeType === ELEMENT_NODE_TYPE && WHITELISTED_HTML_TAGS.indexOf(nodeName) > -1)
+    const tagName = (nodeType === ELEMENT_NODE_TYPE && this.options.whitelistedHtmlTags.indexOf(nodeName) > -1)
       ? nodeName
       : 'span';
 
@@ -55,7 +64,7 @@ export function createElementsFromText(text: string, options: OPTIONS = DEFAULT_
 
     if (attributes && attributes.length) {
       Array.prototype.forEach.call(attributes, (attribute: any) => {
-        if (WHITELISTED_HTML_ATTRIBUTES.indexOf(attribute.nodeName) > -1) {
+        if (this.options.whitelistedHtmlAttributes.indexOf(attribute.nodeName) > -1) {
           Object.assign(newAttributes, { [attribute.nodeName]: attribute.nodeValue });
         }
       });
@@ -63,7 +72,7 @@ export function createElementsFromText(text: string, options: OPTIONS = DEFAULT_
 
     // Preserves whitespace at beginning or end of span tags
     if (tagName === 'span') {
-      newAttributes.style = { whiteSpace: options.whiteSpace };
+      newAttributes.style = { whiteSpace: this.options.whiteSpace };
     }
 
     return React.createElement(tagName, newAttributes, textContent);

--- a/src/test/HtmlTextToReact-test.tsx
+++ b/src/test/HtmlTextToReact-test.tsx
@@ -33,6 +33,18 @@ describe('createElementsFromText', () => {
     expect(wrapper.html()).to.contain('<span style="white-space:pre-wrap">Hello </span><span style="white-space:pre-wrap">Google</span>');
   });
 
+  it('should render form tag if passed as allowable tag', () => {
+    const textUnderTest = 'Hello <form>Google</form>';
+    const wrapper = shallow(<div>{createElementsFromText(textUnderTest, { whitelistedHtmlTags: ['form'] })}</div>);
+    expect(wrapper.html()).to.contain('<form>Google</form>');
+  });
+
+  it('should render data-foo attribute is passed as allowable attribute', () => {
+    const textUnderTest = 'Hello <a data-foo="data-foo-attribute" href="#" />';
+    const wrapper = shallow(<div>{createElementsFromText(textUnderTest, { whitelistedHtmlAttributes: ['data-foo', 'href'] })}</div>);
+    expect(wrapper.html()).to.contain('<a data-foo="data-foo-attribute" href="#"')
+  });
+
   it('should render with specified white-space option', () => {
     const textUnderTest = 'Hello <span>Google</span>';
     const wrapper = shallow(<div>{createElementsFromText(textUnderTest, { whiteSpace: 'normal'})}</div>);


### PR DESCRIPTION
Allow whitelisted tags and attributes to be specified at calltime so that the library can handle multiple use cases